### PR TITLE
feat: /movie pages UI and functionality

### DIFF
--- a/src/components/core/HomeHeader.tsx
+++ b/src/components/core/HomeHeader.tsx
@@ -1,5 +1,5 @@
 import { useGlobalStore } from "@/utils/stores/useGlobalStore";
-import { Link, useMatchRoute } from "@tanstack/react-router";
+import { Link, useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { Menu, Search } from "lucide-react";
 import AnimeSearchDialog from "./media/anime/AnimeSearchDialog";
 import { cn } from "@/lib/utils";
@@ -17,6 +17,7 @@ export default function HomeHeader() {
   );
 
   const matchRoute = useMatchRoute();
+  const navigate = useNavigate();
 
   let searchDialog: ReactNode;
 
@@ -63,10 +64,26 @@ export default function HomeHeader() {
           onClick={() => {
             toggleOpenDialog(
               <div className="flex text-lg font-semibold aspect-video text-mainWhite w-[500px] bg-darkBg">
-                <button className="grid flex-1 bg-mainAccent place-items-center">
+                <button
+                  onClick={() => {
+                    navigate({
+                      to: "/anime"
+                    });
+                    toggleOpenDialog(null);
+                  }}
+                  className="grid flex-1 bg-mainAccent place-items-center"
+                >
                   Anime
                 </button>
-                <button className="grid flex-1 bg-cyan-600 place-items-center">
+                <button
+                  onClick={() => {
+                    navigate({
+                      to: "/movie"
+                    });
+                    toggleOpenDialog(null);
+                  }}
+                  className="grid flex-1 bg-cyan-600 place-items-center"
+                >
                   Movie
                 </button>
                 <button className="grid flex-1 bg-lime-600 place-items-center">

--- a/src/components/core/media/anime/AnimeInfoPageHero.tsx
+++ b/src/components/core/media/anime/AnimeInfoPageHero.tsx
@@ -9,7 +9,7 @@ import InfoSectionBackgroundImage from "@/components/core/media/shared/info/Info
 import Rating from "@/components/core/media/shared/info/Rating";
 import Description from "@/components/core/media/shared/info/Description";
 import InfoSectionPoster from "@/components/core/media/shared/info/InfoSectionPoster";
-import GenreList from "@/components/core/media/shared/info/GenreList";
+import GenreListAnime from "@/components/core/media/shared/info/GenreListAnime";
 import PlayNowButton from "@/components/core/media/shared/info/PlayNowButton";
 import AddToListButton from "@/components/core/media/shared/info/AddToListButton";
 import YearAndStatus from "@/components/core/media/shared/info/YearAndStatus";
@@ -63,7 +63,12 @@ export default function AnimeInfoPageHero({
         <InfoSectionPoster image={image} variant="infoPage" />
         <div className="relative flex flex-col items-center flex-1 gap-3 mt-3 lg:mt-0 lg:items-start">
           <Title title={title} variant="infoPage" />
-          <Rating variant="infoPage" rating={rating} isMobile={false} />
+          <Rating
+            mediaType="anime"
+            variant="infoPage"
+            rating={rating}
+            isMobile={false}
+          />
           <InfoDetails isMobile={false}>
             <div className="flex gap-10">
               <InfoItem label="Year:" info={year?.toString()} />
@@ -91,7 +96,7 @@ export default function AnimeInfoPageHero({
               />
               <InfoItem label="Type:" info={type} />
             </div>
-            <GenreList
+            <GenreListAnime
               variant="infoPage"
               genres={genres}
               gotoLink="/anime/catalog"
@@ -154,14 +159,19 @@ export default function AnimeInfoPageHero({
               />
               <InfoItem label="Type:" info={type} />
             </div>
-            <GenreList
+            <GenreListAnime
               variant="infoPage"
               genres={genres}
               gotoLink="/anime/catalog"
             />
             <div className="flex items-center gap-2">
               <p className="text-gray-400">Score:</p>
-              <Rating variant="infoPage" isMobile rating={rating} />
+              <Rating
+                mediaType="anime"
+                variant="infoPage"
+                isMobile
+                rating={rating}
+              />
             </div>
           </InfoDetails>
         </div>

--- a/src/components/core/media/anime/AnimeSearchDialogResultCard.tsx
+++ b/src/components/core/media/anime/AnimeSearchDialogResultCard.tsx
@@ -1,4 +1,4 @@
-import { getRatingScore } from "@/services/thirdParty/anime/functions/animeFunctions";
+import { getRatingScoreAnime } from "@/services/thirdParty/anime/functions/animeFunctions";
 import { useGlobalStore } from "@/utils/stores/useGlobalStore";
 import { Anime, Status } from "@/utils/types/thirdParty/anime/animeAnilist";
 import { statusLabels } from "@/utils/variables/anime";
@@ -64,7 +64,7 @@ export default function AnimeSearchDialogResultCard({
 
               <div className="flex items-center gap-1">
                 <Star className="size-4" />
-                <p>{getRatingScore(anime.rating * 0.1)}</p>
+                <p>{getRatingScoreAnime(anime.rating * 0.1)}</p>
               </div>
             </div>
           )}

--- a/src/components/core/media/anime/WatchPageAnimeInfo.tsx
+++ b/src/components/core/media/anime/WatchPageAnimeInfo.tsx
@@ -2,7 +2,7 @@ import Description from "@/components/core/media/shared/info/Description";
 import Rating from "@/components/core/media/shared/info/Rating";
 import InfoSectionBackgroundImage from "@/components/core/media/shared/info/InfoSectionBackgroundImage";
 import InfoSectionPoster from "@/components/core/media/shared/info/InfoSectionPoster";
-import GenreList from "@/components/core/media/shared/info/GenreList";
+import GenreListAnime from "@/components/core/media/shared/info/GenreListAnime";
 import Title from "@/components/core/media/shared/info/Title";
 import InfoItem from "@/components/core/media/shared/info/InfoItem";
 import { cn } from "@/lib/utils";
@@ -46,7 +46,7 @@ export default function WatchPageAnimeInfo({
         <section className="z-10 flex flex-col flex-1 gap-2 sm:gap-3">
           <Title title={title} variant="watchPage" />
           <div className="flex flex-col gap-2 mobile-m:gap-4">
-            <Rating variant="watchPage" rating={rating} />
+            <Rating mediaType="anime" variant="watchPage" rating={rating} />
             <div className="flex flex-col gap-2 text-xs sm:text-base mobile-m:gap-3 md:gap-4 lg:gap-8 lg:items-center lg:flex-row">
               <InfoItem label="Year:" info={year?.toString()} />
               <InfoItem
@@ -73,7 +73,7 @@ export default function WatchPageAnimeInfo({
               />
               <InfoItem label="Type:" info={type} />
             </div>
-            <GenreList
+            <GenreListAnime
               isMobile={false}
               genres={genres}
               gotoLink="/anime/catalog"
@@ -89,7 +89,7 @@ export default function WatchPageAnimeInfo({
         </section>
       </div>
       <div className="z-10 w-full space-y-4 lg:space-y-0">
-        <GenreList
+        <GenreListAnime
           isMobile
           genres={genres}
           gotoLink="/anime/catalog"

--- a/src/components/core/media/movie/MovieEpisode.tsx
+++ b/src/components/core/media/movie/MovieEpisode.tsx
@@ -1,0 +1,68 @@
+import { RabbitScraperResponse } from "@/utils/types/thirdParty/shared";
+import { UseQueryResult } from "@tanstack/react-query";
+import EpisodesLoading from "../shared/episode/EpisodesLoading";
+import EpisodesError from "../shared/episode/EpisodesError";
+import EpisodeCard from "../shared/episode/EpisodeCard";
+import EpisodeListContainer from "../shared/episode/EpisodeListContainer";
+import EpisodesContainer from "../shared/episode/EpisodesContainer";
+import EpisodesHeader from "../shared/episode/EpisodesHeader";
+import NoEpisodesAvailable from "../shared/episode/NoEpisodesAvailable";
+
+type MovieEpisodeProps = {
+  variant: "infoPage" | "watchPage";
+  mediaScraperQuery: UseQueryResult<RabbitScraperResponse, Error>;
+  moviePoster: string | null;
+};
+
+export default function MovieEpisode({
+  mediaScraperQuery,
+  variant,
+  moviePoster
+}: MovieEpisodeProps) {
+  const {
+    data: mediaScraperData,
+    isLoading: isMediaScraperLoading,
+    error: mediaScraperError
+  } = mediaScraperQuery;
+
+  if (isMediaScraperLoading) {
+    return <EpisodesLoading />;
+  }
+
+  if (mediaScraperError) {
+    return <EpisodesError isMovie />;
+  }
+
+  if (mediaScraperData) {
+    if (variant === "infoPage") {
+      return (
+        <EpisodesContainer variant="infoPage">
+          <EpisodesHeader />
+          <EpisodeListContainer variant="infoPage">
+            <EpisodeCard
+              episodeNumber={`MOVIE`}
+              episodeTitle={"FULL"}
+              episodeImageFallback={"/no-image-2.jpg"}
+              image={moviePoster}
+            />
+          </EpisodeListContainer>
+        </EpisodesContainer>
+      );
+    }
+    return (
+      <EpisodesContainer variant="watchPage">
+        <EpisodesHeader />
+        <EpisodeListContainer variant="watchPage">
+          <EpisodeCard
+            episodeNumber={`MOVIE`}
+            episodeTitle={"FULL"}
+            isCurrentlyWatched={true}
+            episodeImageFallback={"/no-image-2.jpg"}
+            image={moviePoster}
+          />
+        </EpisodeListContainer>
+      </EpisodesContainer>
+    );
+  }
+  return <NoEpisodesAvailable isMovie={true} />;
+}

--- a/src/components/core/media/movie/MovieInfoPageHero.tsx
+++ b/src/components/core/media/movie/MovieInfoPageHero.tsx
@@ -1,0 +1,120 @@
+import InfoSectionBackgroundImage from "@/components/core/media/shared/info/InfoSectionBackgroundImage";
+import Rating from "@/components/core/media/shared/info/Rating";
+import Description from "@/components/core/media/shared/info/Description";
+import InfoSectionPoster from "@/components/core/media/shared/info/InfoSectionPoster";
+import PlayNowButton from "@/components/core/media/shared/info/PlayNowButton";
+import AddToListButton from "@/components/core/media/shared/info/AddToListButton";
+import YearAndStatus from "@/components/core/media/shared/info/YearAndStatus";
+import Title from "@/components/core/media/shared/info/Title";
+import InfoDetails from "@/components/core/media/shared/info/InfoDetails";
+import InfoItem from "@/components/core/media/shared/info/InfoItem";
+import { TMDBGenre } from "@/utils/types/thirdParty/shared";
+import GenreListTMDB from "../shared/info/GenreListTMDB";
+
+type MovieInfoPageHeroProps = {
+  image: string;
+  cover: string;
+  title: string;
+  runTime: number | null;
+  description: string;
+  year: string;
+  status: string;
+  genres: TMDBGenre[];
+  voteAverage: number | null;
+  //   movieId: string;
+  //   episodesQuery: UseQueryResult<AnimeEpisodesData, Error>;
+};
+
+export default function MovieInfoPageHero({
+  image,
+  cover,
+  title,
+  description,
+  year,
+  status,
+  runTime,
+  genres,
+  voteAverage
+  //   movieId
+  //   episodesQuery
+}: MovieInfoPageHeroProps) {
+  //   const navigate = useNavigate();
+  //   const { data: chunkedEpisodes, isLoading: isChunkEpisodesLoading } =
+  //     useChunkAnimeEpisodes(episodesQuery.data);
+
+  return (
+    <section className="relative flex justify-center w-full text-sm md:text-base">
+      <InfoSectionBackgroundImage image={cover ?? image} variant="infoPage" />
+      <div className="flex flex-col items-center w-full gap-2 pt-32 pb-12 lg:pt-36 lg:gap-14 lg:flex-row lg:items-start">
+        <InfoSectionPoster image={image} variant="infoPage" />
+        <div className="relative flex flex-col items-center flex-1 gap-3 mt-3 lg:mt-0 lg:items-start">
+          <Title title={title} variant="infoPage" />
+          <Rating
+            mediaType="tmdb"
+            variant="infoPage"
+            rating={voteAverage}
+            isMobile={false}
+          />
+          <InfoDetails isMobile={false}>
+            <div className="flex gap-10">
+              <InfoItem label="Year:" info={year} />
+              <InfoItem label="Runtime:" info={`${runTime} min`} />
+              <InfoItem label="Status:" info={status} />
+            </div>
+            <GenreListTMDB
+              variant="infoPage"
+              genres={genres}
+              className="w-full"
+              genreListContainerClassName="max-w-[70%]"
+            />
+          </InfoDetails>
+          <YearAndStatus year={parseInt(year)} status={status} />
+          <div className="flex gap-5 my-3">
+            <PlayNowButton
+            //   disabled={
+            //     episodesQuery.isLoading ||
+            //     episodesQuery.isError ||
+            //     isChunkEpisodesLoading ||
+            //     !chunkedEpisodes
+            //   }
+            //   onClick={() => {
+            //     chunkedEpisodes &&
+            //       navigate({
+            //         to: "/anime/$animeId/watch",
+            //         params: { animeId: animeId },
+            //         search: {
+            //           id: chunkedEpisodes[0].episodes[0].id.replace(/^\//, "")
+            //         }
+            //       });
+            //   }}
+            />
+            <AddToListButton />
+          </div>
+
+          <Description
+            description={description}
+            className="w-full gap-3 mt-5 lg:mt-0 lg:w-[75%] xl:w-[70%]"
+            showDescriptionLabel
+          />
+          <InfoDetails className="mt-14" isMobile>
+            <div className="flex flex-col gap-3">
+              <InfoItem label="Year:" info={year} />
+              <InfoItem label="Runtime:" info={`${runTime} min`} />
+              <InfoItem label="Status:" info={status} />
+            </div>
+            <GenreListTMDB variant="infoPage" genres={genres} />
+            <div className="flex items-center gap-2">
+              <p className="text-gray-400">Score:</p>
+              <Rating
+                mediaType="tmdb"
+                variant="infoPage"
+                isMobile
+                rating={voteAverage}
+              />
+            </div>
+          </InfoDetails>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/core/media/movie/MovieInfoPageHero.tsx
+++ b/src/components/core/media/movie/MovieInfoPageHero.tsx
@@ -8,9 +8,13 @@ import YearAndStatus from "@/components/core/media/shared/info/YearAndStatus";
 import Title from "@/components/core/media/shared/info/Title";
 import InfoDetails from "@/components/core/media/shared/info/InfoDetails";
 import InfoItem from "@/components/core/media/shared/info/InfoItem";
-import { TMDBGenre } from "@/utils/types/thirdParty/shared";
+import {
+  RabbitScraperResponse,
+  TMDBGenre
+} from "@/utils/types/thirdParty/shared";
 import GenreListTMDB from "../shared/info/GenreListTMDB";
 import { useNavigate } from "@tanstack/react-router";
+import { UseQueryResult } from "@tanstack/react-query";
 
 type MovieInfoPageHeroProps = {
   image: string;
@@ -23,7 +27,7 @@ type MovieInfoPageHeroProps = {
   genres: TMDBGenre[];
   voteAverage: number | null;
   movieId: string;
-  movieStreamLink: string | undefined;
+  mediaScraperQuery: UseQueryResult<RabbitScraperResponse, Error>;
 };
 
 export default function MovieInfoPageHero({
@@ -37,9 +41,12 @@ export default function MovieInfoPageHero({
   genres,
   voteAverage,
   movieId,
-  movieStreamLink
+  mediaScraperQuery
 }: MovieInfoPageHeroProps) {
   const navigate = useNavigate();
+
+  const { isLoading: isMediaScraperLoading, error: mediaScraperError } =
+    mediaScraperQuery;
 
   return (
     <section className="relative flex justify-center w-full text-sm md:text-base">
@@ -70,13 +77,12 @@ export default function MovieInfoPageHero({
           <YearAndStatus year={parseInt(year)} status={status} />
           <div className="flex gap-5 my-3">
             <PlayNowButton
-              disabled={!!movieStreamLink}
+              disabled={isMediaScraperLoading || !!mediaScraperError}
               onClick={() => {
-                movieStreamLink &&
-                  navigate({
-                    to: "/movie/$movieId",
-                    params: { movieId }
-                  });
+                navigate({
+                  to: "/movie/$movieId/watch",
+                  params: { movieId }
+                });
               }}
             />
             <AddToListButton />

--- a/src/components/core/media/movie/MovieInfoPageHero.tsx
+++ b/src/components/core/media/movie/MovieInfoPageHero.tsx
@@ -10,6 +10,7 @@ import InfoDetails from "@/components/core/media/shared/info/InfoDetails";
 import InfoItem from "@/components/core/media/shared/info/InfoItem";
 import { TMDBGenre } from "@/utils/types/thirdParty/shared";
 import GenreListTMDB from "../shared/info/GenreListTMDB";
+import { useNavigate } from "@tanstack/react-router";
 
 type MovieInfoPageHeroProps = {
   image: string;
@@ -21,8 +22,8 @@ type MovieInfoPageHeroProps = {
   status: string;
   genres: TMDBGenre[];
   voteAverage: number | null;
-  //   movieId: string;
-  //   episodesQuery: UseQueryResult<AnimeEpisodesData, Error>;
+  movieId: string;
+  movieStreamLink: string | undefined;
 };
 
 export default function MovieInfoPageHero({
@@ -34,13 +35,11 @@ export default function MovieInfoPageHero({
   status,
   runTime,
   genres,
-  voteAverage
-  //   movieId
-  //   episodesQuery
+  voteAverage,
+  movieId,
+  movieStreamLink
 }: MovieInfoPageHeroProps) {
-  //   const navigate = useNavigate();
-  //   const { data: chunkedEpisodes, isLoading: isChunkEpisodesLoading } =
-  //     useChunkAnimeEpisodes(episodesQuery.data);
+  const navigate = useNavigate();
 
   return (
     <section className="relative flex justify-center w-full text-sm md:text-base">
@@ -71,22 +70,14 @@ export default function MovieInfoPageHero({
           <YearAndStatus year={parseInt(year)} status={status} />
           <div className="flex gap-5 my-3">
             <PlayNowButton
-            //   disabled={
-            //     episodesQuery.isLoading ||
-            //     episodesQuery.isError ||
-            //     isChunkEpisodesLoading ||
-            //     !chunkedEpisodes
-            //   }
-            //   onClick={() => {
-            //     chunkedEpisodes &&
-            //       navigate({
-            //         to: "/anime/$animeId/watch",
-            //         params: { animeId: animeId },
-            //         search: {
-            //           id: chunkedEpisodes[0].episodes[0].id.replace(/^\//, "")
-            //         }
-            //       });
-            //   }}
+              disabled={!!movieStreamLink}
+              onClick={() => {
+                movieStreamLink &&
+                  navigate({
+                    to: "/movie/$movieId",
+                    params: { movieId }
+                  });
+              }}
             />
             <AddToListButton />
           </div>

--- a/src/components/core/media/movie/WatrchPageMovieInfo.tsx
+++ b/src/components/core/media/movie/WatrchPageMovieInfo.tsx
@@ -1,0 +1,78 @@
+import Description from "@/components/core/media/shared/info/Description";
+import Rating from "@/components/core/media/shared/info/Rating";
+import InfoSectionBackgroundImage from "@/components/core/media/shared/info/InfoSectionBackgroundImage";
+import InfoSectionPoster from "@/components/core/media/shared/info/InfoSectionPoster";
+import Title from "@/components/core/media/shared/info/Title";
+import InfoItem from "@/components/core/media/shared/info/InfoItem";
+import { TMDBGenre } from "@/utils/types/thirdParty/shared";
+import GenreListTMDB from "../shared/info/GenreListTMDB";
+
+type WatchPageMovieInfoProps = {
+  cover: string;
+  image: string;
+  title: string;
+  description: string;
+  runTime: number;
+  year: string;
+  status: string;
+  genres: TMDBGenre[];
+  voteAverage: number | null;
+};
+
+export default function WatchPageMovieInfo({
+  cover,
+  image,
+  description,
+  year,
+  title,
+  runTime,
+  status,
+  genres,
+  voteAverage
+}: WatchPageMovieInfoProps) {
+  return (
+    <section className="relative flex flex-col w-full gap-6 py-[90px] mt-8 mb-5 justfy-center">
+      <InfoSectionBackgroundImage image={cover ?? image} variant="watchPage" />
+      <div className="z-10 flex gap-3 sm:gap-5 md:gap-8 lg:gap-12 size-full">
+        <InfoSectionPoster image={image} variant="watchPage" />
+        <section className="z-10 flex flex-col flex-1 gap-2 sm:gap-3">
+          <Title title={title} variant="watchPage" />
+          <div className="flex flex-col gap-2 mobile-m:gap-4">
+            <Rating mediaType="tmdb" variant="watchPage" rating={voteAverage} />
+            <div className="flex flex-col gap-2 text-xs sm:text-base mobile-m:gap-3 md:gap-4 lg:gap-8 lg:items-center lg:flex-row">
+              <InfoItem label="Year:" info={year?.toString()} />
+              <InfoItem label="Runtime:" info={`${runTime} min`} />
+              <InfoItem label="Status:" info={status} />
+            </div>
+            <GenreListTMDB
+              isMobile={false}
+              genres={genres}
+              //   gotoLink="/anime/catalog"
+              variant="watchPage"
+            />
+          </div>
+          <Description
+            adjustHeightBasedOnWidth
+            showDescriptionLabel={false}
+            description={description}
+            className="hidden lg:block"
+          />
+        </section>
+      </div>
+      <div className="z-10 w-full space-y-4 lg:space-y-0">
+        <GenreListTMDB
+          isMobile
+          genres={genres}
+          //   gotoLink="/anime/catalog"
+          variant="watchPage"
+        />
+        <Description
+          adjustHeightBasedOnWidth
+          showDescriptionLabel={false}
+          description={description}
+          className="w-full text-sm lg:hidden sm:text-base"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/core/media/shared/episode/EpisodeCard.tsx
+++ b/src/components/core/media/shared/episode/EpisodeCard.tsx
@@ -5,11 +5,11 @@ import EpisodePlayIcon from "./EpisodePlayIcon";
 
 type EpisodeCardProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   image: string | null | undefined;
-  replace: boolean;
+  replace?: boolean;
   episodeImageFallback: string | undefined;
   className?: string;
   isCurrentlyWatched?: boolean;
-  linkProps: LinkProps;
+  linkProps?: LinkProps;
   episodeNumber: string;
   episodeTitle: string;
 };

--- a/src/components/core/media/shared/episode/EpisodesError.tsx
+++ b/src/components/core/media/shared/episode/EpisodesError.tsx
@@ -1,12 +1,17 @@
-export default function EpisodesError() {
+type EpisodesErrorProps = {
+  isMovie?: boolean;
+};
+
+export default function EpisodesError({ isMovie }: EpisodesErrorProps) {
   return (
     <div className="flex flex-col pt-8 pb-16 space-y-6 text-gray-400">
       <p className="text-lg font-semibold lg:text-xl text-mainWhite">
         Episodes
       </p>
       <div className="self-center py-12 text-xl">
-        There was an error fetching episodes for this anime, please try again
-        later.
+        {isMovie
+          ? "There was an error fetching this movie, please try again later."
+          : "There was an error fetching the episodes, please try again later."}
       </div>
     </div>
   );

--- a/src/components/core/media/shared/episode/NoEpisodesAvailable.tsx
+++ b/src/components/core/media/shared/episode/NoEpisodesAvailable.tsx
@@ -1,10 +1,18 @@
-export default function NoEpisodesAvailable() {
+type NoEpisodesAvailableProps = {
+  isMovie?: boolean;
+};
+
+export default function NoEpisodesAvailable({
+  isMovie
+}: NoEpisodesAvailableProps) {
   return (
     <div className="flex flex-col px-2 pt-8 pb-16 space-y-6 text-gray-400 sm:px-3">
       <p className="text-lg font-semibold lg:text-xl text-mainWhite">
         Episodes
       </p>
-      <div className="self-center py-12 text-xl">No Episodes available</div>
+      <div className="self-center py-12 text-xl">
+        {isMovie ? "Movie is currently unavailable." : "No Episodes available"}
+      </div>
     </div>
   );
 }

--- a/src/components/core/media/shared/episode/VideoPlayer.tsx
+++ b/src/components/core/media/shared/episode/VideoPlayer.tsx
@@ -9,15 +9,24 @@ import {
 import { cn } from "@/lib/utils";
 
 type VideoPlayerProps = HTMLAttributes<HTMLDivElement> & {
-  streamLink: string | undefined;
-  headers?: string;
+  streamLink: string | undefined | null;
+  headers?: Record<string, string>;
   className?: string;
   volume?: number;
   title?: string;
 };
 
 export const VideoPlayer = forwardRef<HTMLDivElement, VideoPlayerProps>(
-  ({ headers = "{}", streamLink, className, title, ...props }, ref) => {
+  (
+    {
+      headers = { Referrer: "https://myflixerz.to/" },
+      streamLink,
+      className,
+      title,
+      ...props
+    },
+    ref
+  ) => {
     return (
       <div
         ref={ref}
@@ -33,7 +42,7 @@ export const VideoPlayer = forwardRef<HTMLDivElement, VideoPlayerProps>(
             playsInline
             className="rounded-none size-full"
             title={title}
-            src={`${import.meta.env.VITE_ANIME_PROXY_URL}/proxy?url=${btoa(streamLink)}&headers=${btoa(headers)}`}
+            src={`${import.meta.env.VITE_ANIME_PROXY_URL}/proxy?url=${btoa("https://xelvornwave36.pro/file2/2FzWpgKLzTf~zknNCHNMwv4XdJBJUKOruix7U60CnN7am+rTKxCcqD+Hh5swmwnCpCs3k3XibQRPD61yMATIZ~8BF3XxNaIrnNmMYdryKt4ZGPJgAbpyfcjsYkUh45uJihOsS3QEV5iS8k~mRFNE60Xwi7xjaX9ENOtoMT9WAjc=/cGxheWxpc3QubTN1OA==.m3u8")}&headers=${btoa(JSON.stringify(headers))}`}
             volume={0.08}
           >
             <MediaProvider>

--- a/src/components/core/media/shared/episode/VideoPlayer.tsx
+++ b/src/components/core/media/shared/episode/VideoPlayer.tsx
@@ -1,30 +1,27 @@
 import { forwardRef, HTMLAttributes } from "react";
 import "@vidstack/react/player/styles/default/theme.css";
 import "@vidstack/react/player/styles/default/layouts/video.css";
-import { MediaPlayer, MediaProvider, Poster } from "@vidstack/react";
+import { MediaPlayer, MediaProvider, Poster, Track } from "@vidstack/react";
 import {
   defaultLayoutIcons,
   DefaultVideoLayout
 } from "@vidstack/react/player/layouts/default";
 import { cn } from "@/lib/utils";
+import { Subtitle } from "@/utils/types/thirdParty/shared";
 
 type VideoPlayerProps = HTMLAttributes<HTMLDivElement> & {
   streamLink: string | undefined | null;
+  poster: string | undefined;
   headers?: Record<string, string>;
   className?: string;
   volume?: number;
   title?: string;
+  subtitleTracks?: Subtitle[];
 };
 
 export const VideoPlayer = forwardRef<HTMLDivElement, VideoPlayerProps>(
   (
-    {
-      headers = { Referrer: "https://myflixerz.to/" },
-      streamLink,
-      className,
-      title,
-      ...props
-    },
+    { headers, streamLink, className, poster, title, subtitleTracks, ...props },
     ref
   ) => {
     return (
@@ -42,11 +39,22 @@ export const VideoPlayer = forwardRef<HTMLDivElement, VideoPlayerProps>(
             playsInline
             className="rounded-none size-full"
             title={title}
-            src={`${import.meta.env.VITE_ANIME_PROXY_URL}/proxy?url=${btoa("https://xelvornwave36.pro/file2/2FzWpgKLzTf~zknNCHNMwv4XdJBJUKOruix7U60CnN7am+rTKxCcqD+Hh5swmwnCpCs3k3XibQRPD61yMATIZ~8BF3XxNaIrnNmMYdryKt4ZGPJgAbpyfcjsYkUh45uJihOsS3QEV5iS8k~mRFNE60Xwi7xjaX9ENOtoMT9WAjc=/cGxheWxpc3QubTN1OA==.m3u8")}&headers=${btoa(JSON.stringify(headers))}`}
+            src={`${import.meta.env.VITE_ANIME_PROXY_URL}/proxy?url=${encodeURIComponent(btoa(streamLink))}&headers=${btoa(JSON.stringify(headers))}`}
             volume={0.08}
+            poster={poster}
           >
             <MediaProvider>
               <Poster className="vds-poster" />
+              {subtitleTracks?.map((sub) => (
+                <Track
+                  default
+                  id={sub.url}
+                  kind="subtitles"
+                  src={sub.url}
+                  label={sub.lang}
+                  key={sub.url}
+                />
+              ))}
             </MediaProvider>
             <DefaultVideoLayout icons={defaultLayoutIcons} />
           </MediaPlayer>

--- a/src/components/core/media/shared/info/GenreListAnime.tsx
+++ b/src/components/core/media/shared/info/GenreListAnime.tsx
@@ -18,7 +18,7 @@ type GenreListProps = {
   gotoLink: string;
 } & (InfoPageProps | WatchPageProps);
 
-export default function GenreList({
+export default function GenreListAnime({
   genres,
   gotoLink,
   ...props
@@ -38,7 +38,7 @@ export default function GenreList({
                 <Link
                   to={gotoLink}
                   search={{
-                    genres: `${genre}`,
+                    genres: `${genre}`
                   }}
                   key={i}
                   className="hover:text-mainAccent"
@@ -65,7 +65,7 @@ export default function GenreList({
             <Link
               to="/anime/catalog"
               search={{
-                genres: genre,
+                genres: genre
               }}
               key={genre}
               className="px-3 py-2 transition-colors border rounded-full border-mainAccent/75 hover:text-mainAccent/75"

--- a/src/components/core/media/shared/info/GenreListTMDB.tsx
+++ b/src/components/core/media/shared/info/GenreListTMDB.tsx
@@ -1,0 +1,72 @@
+import { cn } from "@/lib/utils";
+import { TMDBGenre } from "@/utils/types/thirdParty/shared";
+import { Link } from "@tanstack/react-router";
+
+type InfoPageProps = {
+  variant: "infoPage";
+  className?: string;
+  genreListContainerClassName?: string;
+};
+
+type WatchPageProps = {
+  variant: "watchPage";
+  className?: string;
+  isMobile: boolean;
+};
+
+type GenreListTMDBProps = {
+  genres: TMDBGenre[];
+  //   gotoLink: string;
+} & (InfoPageProps | WatchPageProps);
+
+export default function GenreListTMDB({
+  genres,
+  ...props
+}: GenreListTMDBProps) {
+  if (props.variant === "infoPage") {
+    return (
+      <div className={cn("flex gap-2", props.className)}>
+        <p className="text-gray-400">Genres:</p>
+        <ul
+          className={cn(
+            "flex flex-wrap gap-1",
+            props.genreListContainerClassName
+          )}
+        >
+          {genres.length !== 0
+            ? genres.map((genre, i) => (
+                <Link
+                  //   to={gotoLink}
+                  key={i}
+                  className="hover:text-mainAccent"
+                >
+                  {i === genres.length - 1 ? `${genre.name}` : `${genre.name},`}
+                </Link>
+              ))
+            : "N/A"}
+        </ul>
+      </div>
+    );
+  } else {
+    return (
+      <ul
+        className={cn(
+          "flex-wrap gap-2 text-xs mobile-m:gap-3 sm:text-sm",
+          { "flex lg:hidden": props.isMobile },
+          { "lg:flex hidden": !props.isMobile },
+          props.className
+        )}
+      >
+        {genres.length !== 0 &&
+          genres.map((genre) => (
+            <Link
+              key={genre.id}
+              className="px-3 py-2 transition-colors border rounded-full border-mainAccent/75 hover:text-mainAccent/75"
+            >
+              {genre.name}
+            </Link>
+          ))}
+      </ul>
+    );
+  }
+}

--- a/src/components/core/media/shared/info/InfoItem.tsx
+++ b/src/components/core/media/shared/info/InfoItem.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils";
 
 type InfoItemProps = {
   label: string;
-  info: string | undefined
+  info: string | undefined | null;
   className?: string;
   labelClassName?: string;
   infoClassName?: string;
@@ -13,7 +13,7 @@ export default function InfoItem({
   info,
   className,
   labelClassName,
-  infoClassName,
+  infoClassName
 }: InfoItemProps) {
   return (
     <div className={cn("flex items-center gap-2", className)}>

--- a/src/components/core/media/shared/info/Rating.tsx
+++ b/src/components/core/media/shared/info/Rating.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
-import { getRatingScore } from "@/services/thirdParty/anime/functions/animeFunctions";
+import {
+  getRatingScoreAnime,
+  getRatingScoreTMDB
+} from "@/services/thirdParty/anime/functions/animeFunctions";
 
 type InfoPageVariant = {
   variant: "infoPage";
@@ -13,6 +16,7 @@ type WatchPageVariant = {
 
 type StarsRatingProps = {
   rating: number | undefined | null;
+  mediaType: "anime" | "tmdb";
   className?: string;
   starsClassName?: string;
   ratingLabelClassName?: string;
@@ -22,6 +26,7 @@ export default function Rating({
   rating,
   className,
   starsClassName,
+  mediaType,
   ratingLabelClassName,
   variant,
   ...props
@@ -45,7 +50,7 @@ export default function Rating({
         variant === "infoPage"
           ? {
               "flex lg:hidden ml-0": infoPageProps?.isMobile,
-              "hidden lg:flex ml-2": !infoPageProps?.isMobile,
+              "hidden lg:flex ml-2": !infoPageProps?.isMobile
             }
           : "flex gap-2 mobile-l:gap-4 xl:ml-2",
         className
@@ -56,14 +61,14 @@ export default function Rating({
           WebkitMaskImage: 'url("/five-stars.svg")',
           WebkitMaskSize: "contain",
           WebkitMaskRepeat: "no-repeat",
-          WebkitMaskPosition: "center",
+          WebkitMaskPosition: "center"
         }}
         className={cn(
           "relative w-32 h-6 bg-gray-500 lg:-ml-2",
           {
             "w-20 h-full mobile-m:w-24 sm:w-28 lg:w-32 lg:h-5 xl:h-6":
               variant === "watchPage",
-            "w-24": variant === "infoPage" && infoPageProps?.isMobile,
+            "w-24": variant === "infoPage" && infoPageProps?.isMobile
           },
           starsClassName
         )}
@@ -71,7 +76,7 @@ export default function Rating({
         <div
           ref={starsFillWidthRef}
           style={{
-            width: `${starsFillWidthPercentage}%`,
+            width: `${starsFillWidthPercentage}%`
           }}
           className={`absolute bg-amber-400 h-full`}
         ></div>
@@ -81,15 +86,17 @@ export default function Rating({
           "font-semibold lg:text-lg",
           {
             "text-xs mobile-l:text-sm sm:text-base md:text-lg":
-              variant === "watchPage",
+              variant === "watchPage"
           },
           ratingLabelClassName
         )}
       >
         <span className="text-mainAccent">
-          {rating ? `${getRatingScore(rating)}` : "?"}
+          {rating
+            ? `${mediaType === "anime" ? getRatingScoreAnime(rating) : getRatingScoreTMDB(rating)}`
+            : "?"}
         </span>
-        /5
+        {mediaType === "anime" ? "/5" : "/10"}
       </p>
     </div>
   );

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as ProtectedSocialSearchPostsIndexImport } from './routes/_protec
 import { Route as ProtectedSocialSearchPeopleIndexImport } from './routes/_protected/social/search/people/index'
 import { Route as ProtectedSocialUserHandlePostsIndexImport } from './routes/_protected/social/$userHandle_/posts/index'
 import { Route as ProtectedSocialUserHandleCollectionsIndexImport } from './routes/_protected/social/$userHandle/collections/index'
+import { Route as ProtectedMovieMovieIdWatchIndexImport } from './routes/_protected/movie/$movieId/watch/index'
 import { Route as ProtectedAnimeAnimeIdWatchIndexImport } from './routes/_protected/anime/$animeId/watch/index'
 import { Route as AuthLoginForgotPasswordVerifyEmailIndexImport } from './routes/_auth/login/forgot-password/verify-email/index'
 import { Route as AuthLoginForgotPasswordFindAccountIndexImport } from './routes/_auth/login/forgot-password/find-account/index'
@@ -175,6 +176,12 @@ const ProtectedSocialUserHandleCollectionsIndexRoute =
   ProtectedSocialUserHandleCollectionsIndexImport.update({
     path: '/collections/',
     getParentRoute: () => ProtectedSocialUserHandleRouteRoute,
+  } as any)
+
+const ProtectedMovieMovieIdWatchIndexRoute =
+  ProtectedMovieMovieIdWatchIndexImport.update({
+    path: '/movie/$movieId/watch/',
+    getParentRoute: () => ProtectedRouteRoute,
   } as any)
 
 const ProtectedAnimeAnimeIdWatchIndexRoute =
@@ -378,6 +385,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedAnimeAnimeIdWatchIndexImport
       parentRoute: typeof ProtectedRouteImport
     }
+    '/_protected/movie/$movieId/watch/': {
+      id: '/_protected/movie/$movieId/watch/'
+      path: '/movie/$movieId/watch'
+      fullPath: '/movie/$movieId/watch'
+      preLoaderRoute: typeof ProtectedMovieMovieIdWatchIndexImport
+      parentRoute: typeof ProtectedRouteImport
+    }
     '/_protected/social/$userHandle/collections/': {
       id: '/_protected/social/$userHandle/collections/'
       path: '/collections'
@@ -461,6 +475,7 @@ export const routeTree = rootRoute.addChildren({
     ProtectedAnimeCatalogIndexRoute,
     ProtectedMovieMovieIdIndexRoute,
     ProtectedAnimeAnimeIdWatchIndexRoute,
+    ProtectedMovieMovieIdWatchIndexRoute,
   }),
 })
 
@@ -502,7 +517,8 @@ export const routeTree = rootRoute.addChildren({
         "/_protected/anime/$animeId/",
         "/_protected/anime/catalog/",
         "/_protected/movie/$movieId/",
-        "/_protected/anime/$animeId/watch/"
+        "/_protected/anime/$animeId/watch/",
+        "/_protected/movie/$movieId/watch/"
       ]
     },
     "/_protected/social": {
@@ -600,6 +616,10 @@ export const routeTree = rootRoute.addChildren({
     },
     "/_protected/anime/$animeId/watch/": {
       "filePath": "_protected/anime/$animeId/watch/index.tsx",
+      "parent": "/_protected"
+    },
+    "/_protected/movie/$movieId/watch/": {
+      "filePath": "_protected/movie/$movieId/watch/index.tsx",
       "parent": "/_protected"
     },
     "/_protected/social/$userHandle/collections/": {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as AuthRouteImport } from './routes/_auth/route'
 import { Route as IndexImport } from './routes/index'
 import { Route as ProtectedSocialRouteImport } from './routes/_protected/social/route'
 import { Route as ProtectedSocialIndexImport } from './routes/_protected/social/index'
+import { Route as ProtectedMovieIndexImport } from './routes/_protected/movie/index'
 import { Route as ProtectedAnimeIndexImport } from './routes/_protected/anime/index'
 import { Route as AuthSignupIndexImport } from './routes/_auth/signup/index'
 import { Route as AuthLoginIndexImport } from './routes/_auth/login/index'
@@ -24,6 +25,7 @@ import { Route as ProtectedSocialSearchRouteImport } from './routes/_protected/s
 import { Route as ProtectedSocialUserHandleRouteImport } from './routes/_protected/social/$userHandle/route'
 import { Route as ProtectedSocialSearchIndexImport } from './routes/_protected/social/search/index'
 import { Route as ProtectedSocialUserHandleIndexImport } from './routes/_protected/social/$userHandle/index'
+import { Route as ProtectedMovieMovieIdIndexImport } from './routes/_protected/movie/$movieId/index'
 import { Route as ProtectedAnimeCatalogIndexImport } from './routes/_protected/anime/catalog/index'
 import { Route as ProtectedAnimeAnimeIdIndexImport } from './routes/_protected/anime/$animeId/index'
 import { Route as AuthSignupVerifyEmailIndexImport } from './routes/_auth/signup/verify-email/index'
@@ -64,6 +66,11 @@ const ProtectedSocialRouteRoute = ProtectedSocialRouteImport.update({
 const ProtectedSocialIndexRoute = ProtectedSocialIndexImport.update({
   path: '/',
   getParentRoute: () => ProtectedSocialRouteRoute,
+} as any)
+
+const ProtectedMovieIndexRoute = ProtectedMovieIndexImport.update({
+  path: '/movie/',
+  getParentRoute: () => ProtectedRouteRoute,
 } as any)
 
 const ProtectedAnimeIndexRoute = ProtectedAnimeIndexImport.update({
@@ -111,6 +118,13 @@ const ProtectedSocialUserHandleIndexRoute =
     path: '/',
     getParentRoute: () => ProtectedSocialUserHandleRouteRoute,
   } as any)
+
+const ProtectedMovieMovieIdIndexRoute = ProtectedMovieMovieIdIndexImport.update(
+  {
+    path: '/movie/$movieId/',
+    getParentRoute: () => ProtectedRouteRoute,
+  } as any,
+)
 
 const ProtectedAnimeCatalogIndexRoute = ProtectedAnimeCatalogIndexImport.update(
   {
@@ -273,6 +287,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedAnimeIndexImport
       parentRoute: typeof ProtectedRouteImport
     }
+    '/_protected/movie/': {
+      id: '/_protected/movie/'
+      path: '/movie'
+      fullPath: '/movie'
+      preLoaderRoute: typeof ProtectedMovieIndexImport
+      parentRoute: typeof ProtectedRouteImport
+    }
     '/_protected/social/': {
       id: '/_protected/social/'
       path: '/'
@@ -306,6 +327,13 @@ declare module '@tanstack/react-router' {
       path: '/anime/catalog'
       fullPath: '/anime/catalog'
       preLoaderRoute: typeof ProtectedAnimeCatalogIndexImport
+      parentRoute: typeof ProtectedRouteImport
+    }
+    '/_protected/movie/$movieId/': {
+      id: '/_protected/movie/$movieId/'
+      path: '/movie/$movieId'
+      fullPath: '/movie/$movieId'
+      preLoaderRoute: typeof ProtectedMovieMovieIdIndexImport
       parentRoute: typeof ProtectedRouteImport
     }
     '/_protected/social/$userHandle/': {
@@ -428,8 +456,10 @@ export const routeTree = rootRoute.addChildren({
       ProtectedSocialUserHandlePostsPostIdIndexRoute,
     }),
     ProtectedAnimeIndexRoute,
+    ProtectedMovieIndexRoute,
     ProtectedAnimeAnimeIdIndexRoute,
     ProtectedAnimeCatalogIndexRoute,
+    ProtectedMovieMovieIdIndexRoute,
     ProtectedAnimeAnimeIdWatchIndexRoute,
   }),
 })
@@ -468,8 +498,10 @@ export const routeTree = rootRoute.addChildren({
       "children": [
         "/_protected/social",
         "/_protected/anime/",
+        "/_protected/movie/",
         "/_protected/anime/$animeId/",
         "/_protected/anime/catalog/",
+        "/_protected/movie/$movieId/",
         "/_protected/anime/$animeId/watch/"
       ]
     },
@@ -518,6 +550,10 @@ export const routeTree = rootRoute.addChildren({
       "filePath": "_protected/anime/index.tsx",
       "parent": "/_protected"
     },
+    "/_protected/movie/": {
+      "filePath": "_protected/movie/index.tsx",
+      "parent": "/_protected"
+    },
     "/_protected/social/": {
       "filePath": "_protected/social/index.tsx",
       "parent": "/_protected/social"
@@ -536,6 +572,10 @@ export const routeTree = rootRoute.addChildren({
     },
     "/_protected/anime/catalog/": {
       "filePath": "_protected/anime/catalog/index.tsx",
+      "parent": "/_protected"
+    },
+    "/_protected/movie/$movieId/": {
+      "filePath": "_protected/movie/$movieId/index.tsx",
       "parent": "/_protected"
     },
     "/_protected/social/$userHandle/": {

--- a/src/routes/_protected/anime/$animeId/watch/index.tsx
+++ b/src/routes/_protected/anime/$animeId/watch/index.tsx
@@ -108,6 +108,11 @@ function WatchEpisodePage() {
         <section className="flex flex-col w-full gap-2 pt-20 lg:pt-24 lg:gap-6 lg:flex-row">
           <div ref={videoAndEpisodeInfoContainerRef} className="w-full h-fit">
             <VideoPlayer
+              poster={
+                episodeInfo.image ||
+                animeInfoAnilist.cover ||
+                animeInfoAnify.bannerImage
+              }
               streamLink={
                 episodeStreamLinks.sources.find(
                   (source) => source.quality === "backup"

--- a/src/routes/_protected/anime/index.tsx
+++ b/src/routes/_protected/anime/index.tsx
@@ -118,7 +118,7 @@ function AnimeHomePage() {
                 </CategoryCarouselItem>
               );
             }}
-            categoryName="Trending Anime"
+            categoryName="Trending"
           />
         )}
         {topRatedAnimes && (

--- a/src/routes/_protected/movie/$movieId/index.tsx
+++ b/src/routes/_protected/movie/$movieId/index.tsx
@@ -1,0 +1,111 @@
+import MovieInfoPageHero from "@/components/core/media/movie/MovieInfoPageHero";
+import CategoryCarousel from "@/components/core/media/shared/carousel/CategoryCarousel";
+import CategoryCarouselItem from "@/components/core/media/shared/carousel/CategoryCarouselItem";
+import MediaCard from "@/components/core/media/shared/MediaCard";
+import {
+  useMovieInfo,
+  useMovieRecommendations
+} from "@/services/thirdParty/movie/movieQueries";
+import {
+  getTMDBImageURL,
+  getTMDBReleaseYear
+} from "@/services/thirdParty/sharedFunctions";
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export const Route = createFileRoute("/_protected/movie/$movieId/")({
+  component: () => <MovieInfoPage />
+});
+
+function MovieInfoPage() {
+  const { movieId } = Route.useParams();
+
+  // const episodesQuery = useFetchAnimeEpisodes(animeId);
+
+  const {
+    data: movieInfo,
+    isLoading: isMovieInfoLoading,
+    error: movieInfoError
+  } = useMovieInfo(movieId);
+
+  const {
+    data: movieRecommendations,
+    isLoading: isMovieRecommendationsLoading,
+    error: movieRecommendationsError
+  } = useMovieRecommendations(movieId);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  if (isMovieInfoLoading || isMovieRecommendationsLoading) {
+    return (
+      <div className="grid text-2xl text-white bg-darkBg h-dvh place-items-center">
+        <p>
+          LOADING&nbsp;
+          <span className="font-semibold text-green-500">MOVIE INFO</span>
+        </p>
+      </div>
+    );
+  }
+
+  if (movieInfoError || movieRecommendationsError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen bg-darkBg">
+        <p>Oops! There was an error fetching the details for this anime.</p>
+        <p>Please try again later.</p>
+      </div>
+    );
+  }
+
+  if (movieInfo && movieRecommendations) {
+    return (
+      <main className="w-full pb-32">
+        <MovieInfoPageHero
+          cover={getTMDBImageURL(movieInfo.backdrop_path)}
+          description={movieInfo.overview}
+          genres={movieInfo.genres}
+          image={getTMDBImageURL(movieInfo.poster_path)}
+          year={getTMDBReleaseYear(movieInfo.release_date)}
+          runTime={movieInfo.runtime}
+          status={movieInfo.status}
+          title={movieInfo.title}
+          voteAverage={movieInfo.vote_average}
+        />
+        {/* <AnimeEpisodes
+          variant="infoPage"
+          episodesQuery={episodesQuery}
+          animeId={animeId}
+          replace={false}
+          type={animeInfoAnilist?.type}
+          episodeImageFallback={
+            animeInfoAnilist?.cover ||
+            animeInfoAnify?.coverImage ||
+            animeInfoAnilist?.image ||
+            animeInfoAnify?.bannerImage
+          }
+        /> */}
+        {movieRecommendations.results.length !== 0 && (
+          <CategoryCarousel
+            carouselItems={movieRecommendations.results}
+            categoryName="Recommendations:"
+            renderCarouselItems={(recommendation) => {
+              return (
+                <CategoryCarouselItem key={recommendation.id}>
+                  <MediaCard
+                    image={getTMDBImageURL(recommendation.poster_path)}
+                    linkProps={{}}
+                    subLabels={[
+                      getTMDBReleaseYear(recommendation.release_date)
+                    ]}
+                    title={recommendation.title}
+                  />
+                </CategoryCarouselItem>
+              );
+            }}
+          />
+        )}
+      </main>
+    );
+  }
+}

--- a/src/routes/_protected/movie/$movieId/index.tsx
+++ b/src/routes/_protected/movie/$movieId/index.tsx
@@ -1,10 +1,15 @@
 import MovieInfoPageHero from "@/components/core/media/movie/MovieInfoPageHero";
 import CategoryCarousel from "@/components/core/media/shared/carousel/CategoryCarousel";
 import CategoryCarouselItem from "@/components/core/media/shared/carousel/CategoryCarouselItem";
+import EpisodeCard from "@/components/core/media/shared/episode/EpisodeCard";
+import EpisodeListContainer from "@/components/core/media/shared/episode/EpisodeListContainer";
+import EpisodesContainer from "@/components/core/media/shared/episode/EpisodesContainer";
+import EpisodesHeader from "@/components/core/media/shared/episode/EpisodesHeader";
 import MediaCard from "@/components/core/media/shared/MediaCard";
 import {
   useMovieInfo,
-  useMovieRecommendations
+  useMovieRecommendations,
+  useMovieStreamLink
 } from "@/services/thirdParty/movie/movieQueries";
 import {
   getTMDBImageURL,
@@ -20,8 +25,6 @@ export const Route = createFileRoute("/_protected/movie/$movieId/")({
 function MovieInfoPage() {
   const { movieId } = Route.useParams();
 
-  // const episodesQuery = useFetchAnimeEpisodes(animeId);
-
   const {
     data: movieInfo,
     isLoading: isMovieInfoLoading,
@@ -34,11 +37,21 @@ function MovieInfoPage() {
     error: movieRecommendationsError
   } = useMovieRecommendations(movieId);
 
+  const {
+    data: movieStreamLink,
+    isLoading: isMovieStreamLinkLoading,
+    error: movieStreamLinkError
+  } = useMovieStreamLink(movieId, !!movieInfo);
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  if (isMovieInfoLoading || isMovieRecommendationsLoading) {
+  if (
+    isMovieInfoLoading ||
+    isMovieRecommendationsLoading ||
+    isMovieStreamLinkLoading
+  ) {
     return (
       <div className="grid text-2xl text-white bg-darkBg h-dvh place-items-center">
         <p>
@@ -49,7 +62,7 @@ function MovieInfoPage() {
     );
   }
 
-  if (movieInfoError || movieRecommendationsError) {
+  if (movieInfoError || movieRecommendationsError || movieStreamLinkError) {
     return (
       <div className="flex flex-col items-center justify-center h-screen bg-darkBg">
         <p>Oops! There was an error fetching the details for this anime.</p>
@@ -58,10 +71,12 @@ function MovieInfoPage() {
     );
   }
 
-  if (movieInfo && movieRecommendations) {
+  if (movieInfo && movieRecommendations && movieStreamLink) {
     return (
       <main className="w-full pb-32">
         <MovieInfoPageHero
+          movieId={movieId}
+          movieStreamLink={movieStreamLink}
           cover={getTMDBImageURL(movieInfo.backdrop_path)}
           description={movieInfo.overview}
           genres={movieInfo.genres}
@@ -72,19 +87,21 @@ function MovieInfoPage() {
           title={movieInfo.title}
           voteAverage={movieInfo.vote_average}
         />
-        {/* <AnimeEpisodes
-          variant="infoPage"
-          episodesQuery={episodesQuery}
-          animeId={animeId}
-          replace={false}
-          type={animeInfoAnilist?.type}
-          episodeImageFallback={
-            animeInfoAnilist?.cover ||
-            animeInfoAnify?.coverImage ||
-            animeInfoAnilist?.image ||
-            animeInfoAnify?.bannerImage
-          }
-        /> */}
+        <EpisodesContainer variant="infoPage">
+          <EpisodesHeader />
+          <EpisodeListContainer variant="infoPage">
+            <EpisodeCard
+              linkProps={{
+                to: "/movie/$movieId/watch"
+              }}
+              episodeNumber={`MOVIE`}
+              episodeTitle={"FULL"}
+              isCurrentlyWatched={false}
+              episodeImageFallback={"/no-image-2.jpg"}
+              image={getTMDBImageURL(movieInfo.poster_path)}
+            />
+          </EpisodeListContainer>
+        </EpisodesContainer>
         {movieRecommendations.results.length !== 0 && (
           <CategoryCarousel
             carouselItems={movieRecommendations.results}

--- a/src/routes/_protected/movie/$movieId/watch/index.tsx
+++ b/src/routes/_protected/movie/$movieId/watch/index.tsx
@@ -1,0 +1,152 @@
+import WatchPageMovieInfo from "@/components/core/media/movie/WatrchPageMovieInfo";
+import CategoryCarousel from "@/components/core/media/shared/carousel/CategoryCarousel";
+import CategoryCarouselItem from "@/components/core/media/shared/carousel/CategoryCarouselItem";
+import EpisodeCard from "@/components/core/media/shared/episode/EpisodeCard";
+import EpisodeListContainer from "@/components/core/media/shared/episode/EpisodeListContainer";
+import EpisodesContainer from "@/components/core/media/shared/episode/EpisodesContainer";
+import EpisodesHeader from "@/components/core/media/shared/episode/EpisodesHeader";
+import EpisodeTitleAndNumber from "@/components/core/media/shared/episode/EpisodeTitleAndNumber";
+import { VideoPlayer } from "@/components/core/media/shared/episode/VideoPlayer";
+import MediaCard from "@/components/core/media/shared/MediaCard";
+import {
+  useMovieInfo,
+  useMovieStreamLink,
+  useMovieRecommendations
+} from "@/services/thirdParty/movie/movieQueries";
+import {
+  getTMDBImageURL,
+  getTMDBReleaseYear
+} from "@/services/thirdParty/sharedFunctions";
+import { useWindowWidth } from "@/utils/hooks/useWindowWidth";
+import { createFileRoute } from "@tanstack/react-router";
+import { useRef, useState, useEffect } from "react";
+
+export const Route = createFileRoute("/_protected/movie/$movieId/watch/")({
+  component: () => <WatchMoviePage />
+});
+
+function WatchMoviePage() {
+  const { movieId } = Route.useParams();
+  const videoAndEpisodeInfoContainerRef = useRef<HTMLDivElement | null>(null);
+  const [
+    videoAndeEpisodeInfoContainerHeight,
+    setVideoAndEpisodeInfoContainerHeight
+  ] = useState(0);
+
+  const windowWidth = useWindowWidth();
+
+  const {
+    data: movieInfo,
+    isLoading: isMovieInfoLoading,
+    error: movieInfoError
+  } = useMovieInfo(movieId);
+
+  const {
+    data: movieRecommendations,
+    isLoading: isMovieRecommendationsLoading,
+    error: movieRecommendationsError
+  } = useMovieRecommendations(movieId);
+
+  const {
+    data: movieStreamLink,
+    isLoading: isMovieStreamLinkLoading,
+    error: movieStreamLinkError
+  } = useMovieStreamLink(movieId, !!movieInfo);
+
+  //sets the videoAndEpisodeInfoContainerHeight everytime window width changes
+  useEffect(() => {
+    if (videoAndEpisodeInfoContainerRef.current) {
+      setVideoAndEpisodeInfoContainerHeight(
+        videoAndEpisodeInfoContainerRef.current.getBoundingClientRect().height
+      );
+    }
+  }, [movieStreamLink, movieInfo, windowWidth]);
+
+  if (
+    isMovieStreamLinkLoading ||
+    isMovieInfoLoading ||
+    isMovieRecommendationsLoading
+  ) {
+    return (
+      <div className="grid text-2xl text-white h-dvh place-items-center">
+        <p>
+          LOADING&nbsp;
+          <span className="font-semibold text-red-500">EPISODE</span>
+        </p>
+      </div>
+    );
+  }
+  if (movieStreamLinkError || movieInfoError || movieRecommendationsError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen bg-darkBg">
+        <p>Oops! There was an error fetching this movie.</p>
+        <p>Please try again later.</p>
+      </div>
+    );
+  }
+
+  if (movieStreamLink && movieInfo) {
+    return (
+      <main className="flex flex-col pb-32">
+        <section className="flex flex-col w-full gap-2 pt-20 lg:pt-24 lg:gap-6 lg:flex-row">
+          <div ref={videoAndEpisodeInfoContainerRef} className="w-full h-fit">
+            <VideoPlayer streamLink={movieStreamLink} title={"MOVIE"} />
+            <EpisodeTitleAndNumber
+              episodeNumber={movieInfo.title}
+              episodeTitle={"MOVIE"}
+            />
+          </div>
+          <EpisodesContainer
+            variant="watchPage"
+            episodeListMaxHeight={videoAndeEpisodeInfoContainerHeight}
+          >
+            <EpisodesHeader />
+            <EpisodeListContainer variant="watchPage">
+              <EpisodeCard
+                episodeNumber={`MOVIE`}
+                episodeTitle={"FULL"}
+                isCurrentlyWatched={true}
+                episodeImageFallback={"/no-image-2.jpg"}
+                image={getTMDBImageURL(movieInfo.poster_path)}
+              />
+            </EpisodeListContainer>
+          </EpisodesContainer>
+        </section>
+        <WatchPageMovieInfo
+          voteAverage={movieInfo.vote_average}
+          cover={getTMDBImageURL(movieInfo.backdrop_path)}
+          description={movieInfo.overview}
+          genres={movieInfo.genres}
+          image={getTMDBImageURL(movieInfo.poster_path)}
+          runTime={movieInfo.runtime}
+          status={movieInfo.status}
+          title={movieInfo.title}
+          year={getTMDBReleaseYear(movieInfo.release_date)}
+        />
+        {movieRecommendations && (
+          <CategoryCarousel
+            carouselItems={movieRecommendations.results}
+            categoryName="Recommendations:"
+            renderCarouselItems={(recommendation, i) => {
+              return (
+                <CategoryCarouselItem key={recommendation.id || i}>
+                  <MediaCard
+                    image={getTMDBImageURL(recommendation.poster_path)}
+                    linkProps={{
+                      to: "/anime/$animeId",
+                      params: { animeId: `${recommendation.id}` }
+                    }}
+                    subLabels={[
+                      getTMDBReleaseYear(recommendation.release_date)
+                    ]}
+                    title={recommendation.title}
+                  />
+                </CategoryCarouselItem>
+              );
+            }}
+          />
+        )}
+      </main>
+    );
+  }
+}

--- a/src/routes/_protected/movie/index.tsx
+++ b/src/routes/_protected/movie/index.tsx
@@ -8,7 +8,6 @@ import {
   getTMDBImageURL,
   getTMDBReleaseYear
 } from "@/services/thirdParty/sharedFunctions";
-import { SortBy } from "@/utils/types/thirdParty/anime/animeAnilist";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_protected/movie/")({
@@ -84,12 +83,12 @@ function MovieHomePage() {
       <div className="w-full pt-8 pb-24 space-y-10">
         {trendingMovies && (
           <CategoryCarousel
-            gotoLinkProps={{
-              to: "/anime/catalog",
-              search: {
-                sortBy: SortBy.TRENDING_DESC
-              }
-            }}
+            // gotoLinkProps={{
+            //   to: "/anime/catalog",
+            //   search: {
+            //     sortBy: SortBy.TRENDING_DESC
+            //   }
+            // }}
             carouselItems={trendingMovies.results.slice(5, 17)}
             renderCarouselItems={(movie, i) => {
               return (
@@ -111,12 +110,12 @@ function MovieHomePage() {
         )}
         {popularMovies && (
           <CategoryCarousel
-            gotoLinkProps={{
-              to: "/anime/catalog",
-              search: {
-                sortBy: SortBy.POPULARITY_DESC
-              }
-            }}
+            // gotoLinkProps={{
+            //   to: "/anime/catalog",
+            //   search: {
+            //     sortBy: SortBy.POPULARITY_DESC
+            //   }
+            // }}
             carouselItems={popularMovies.results.slice(0, 12)}
             renderCarouselItems={(movie, i) => {
               return (
@@ -138,12 +137,12 @@ function MovieHomePage() {
         )}
         {topRatedMovies && (
           <CategoryCarousel
-            gotoLinkProps={{
-              to: "/anime/catalog",
-              search: {
-                sortBy: SortBy.SCORE_DESC
-              }
-            }}
+            // gotoLinkProps={{
+            //   to: "/anime/catalog",
+            //   search: {
+            //     sortBy: SortBy.SCORE_DESC
+            //   }
+            // }}
             carouselItems={topRatedMovies.results.slice(0, 12)}
             renderCarouselItems={(movie, i) => {
               return (

--- a/src/routes/_protected/movie/index.tsx
+++ b/src/routes/_protected/movie/index.tsx
@@ -1,0 +1,169 @@
+import CategoryCarousel from "@/components/core/media/shared/carousel/CategoryCarousel";
+import CategoryCarouselItem from "@/components/core/media/shared/carousel/CategoryCarouselItem";
+import TrendingHeroCarousel from "@/components/core/media/shared/carousel/TrendingHeroCarousel";
+import TrendingHeroCarouselItem from "@/components/core/media/shared/carousel/TrendingHeroCarouselItem";
+import MediaCard from "@/components/core/media/shared/MediaCard";
+import { useMoviesByCategory } from "@/services/thirdParty/movie/movieQueries";
+import {
+  getTMDBImageURL,
+  getTMDBReleaseYear
+} from "@/services/thirdParty/sharedFunctions";
+import { SortBy } from "@/utils/types/thirdParty/anime/animeAnilist";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_protected/movie/")({
+  component: () => <MovieHomePage />
+});
+
+function MovieHomePage() {
+  const {
+    data: trendingMovies,
+    isLoading: isTrendingMoviesLoading,
+    error: trendingMoviesError
+  } = useMoviesByCategory("trending");
+  const {
+    data: popularMovies,
+    isLoading: isPopularMoviesLoading,
+    error: popularMoviesError
+  } = useMoviesByCategory("popular");
+  const {
+    data: topRatedMovies,
+    isLoading: isTopRatedMoviesLoading,
+    error: topRatedMoviesError
+  } = useMoviesByCategory("topRated");
+
+  if (
+    isTrendingMoviesLoading ||
+    isPopularMoviesLoading ||
+    isTopRatedMoviesLoading
+  ) {
+    return (
+      <div className="grid text-2xl text-white bg-darkBg h-dvh place-items-center">
+        <p>
+          Loading&nbsp;
+          <span className="font-semibold text-mainAccent">AzuraWatch</span>
+        </p>
+      </div>
+    );
+  }
+
+  if (trendingMoviesError && popularMoviesError && topRatedMoviesError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen bg-darkBg">
+        <p>Oops! There was an error fetching this page.</p>
+        <p>Please try again later.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center w-full">
+      {trendingMovies && (
+        <div className="w-dvw max-w-[100dvw]">
+          <TrendingHeroCarousel
+            carouselItems={trendingMovies.results.slice(0, 5)}
+            renderCarouselItems={(movie, i) => (
+              <TrendingHeroCarouselItem
+                key={i}
+                backgroundImage={getTMDBImageURL(movie.backdrop_path)}
+                posterImage={getTMDBImageURL(movie.poster_path)}
+                description={movie.overview}
+                title={movie.title}
+                trendingRank={i + 1}
+                toInfoPageLinkProps={{
+                  to: "/movie/$movieId",
+                  params: {
+                    movieId: movie.id.toString()
+                  }
+                }}
+              />
+            )}
+          />
+        </div>
+      )}
+      <div className="w-full pt-8 pb-24 space-y-10">
+        {trendingMovies && (
+          <CategoryCarousel
+            gotoLinkProps={{
+              to: "/anime/catalog",
+              search: {
+                sortBy: SortBy.TRENDING_DESC
+              }
+            }}
+            carouselItems={trendingMovies.results.slice(5, 17)}
+            renderCarouselItems={(movie, i) => {
+              return (
+                <CategoryCarouselItem key={movie.id || i}>
+                  <MediaCard
+                    image={getTMDBImageURL(movie.poster_path)}
+                    linkProps={{
+                      to: "/movie/$movieId",
+                      params: { movieId: movie.id.toString() }
+                    }}
+                    subLabels={[getTMDBReleaseYear(movie.release_date)]}
+                    title={movie.title}
+                  />
+                </CategoryCarouselItem>
+              );
+            }}
+            categoryName="Trending"
+          />
+        )}
+        {popularMovies && (
+          <CategoryCarousel
+            gotoLinkProps={{
+              to: "/anime/catalog",
+              search: {
+                sortBy: SortBy.POPULARITY_DESC
+              }
+            }}
+            carouselItems={popularMovies.results.slice(0, 12)}
+            renderCarouselItems={(movie, i) => {
+              return (
+                <CategoryCarouselItem key={movie.id || i}>
+                  <MediaCard
+                    image={getTMDBImageURL(movie.poster_path)}
+                    linkProps={{
+                      to: "/movie/$movieId",
+                      params: { movieId: movie.id.toString() }
+                    }}
+                    subLabels={[getTMDBReleaseYear(movie.release_date)]}
+                    title={movie.title}
+                  />
+                </CategoryCarouselItem>
+              );
+            }}
+            categoryName="Currently Popular"
+          />
+        )}
+        {topRatedMovies && (
+          <CategoryCarousel
+            gotoLinkProps={{
+              to: "/anime/catalog",
+              search: {
+                sortBy: SortBy.SCORE_DESC
+              }
+            }}
+            carouselItems={topRatedMovies.results.slice(0, 12)}
+            renderCarouselItems={(movie, i) => {
+              return (
+                <CategoryCarouselItem key={movie.id || i}>
+                  <MediaCard
+                    image={getTMDBImageURL(movie.poster_path)}
+                    linkProps={{
+                      to: "/movie/$movieId",
+                      params: { movieId: movie.id.toString() }
+                    }}
+                    subLabels={[getTMDBReleaseYear(movie.release_date)]}
+                    title={movie.title}
+                  />
+                </CategoryCarouselItem>
+              );
+            }}
+            categoryName="Top Rated"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/services/thirdParty/anime/functions/animeFunctions.ts
+++ b/src/services/thirdParty/anime/functions/animeFunctions.ts
@@ -78,8 +78,12 @@ export function getEpisodesToBeRendered(
   }
 }
 
-export function getRatingScore(rating: number) {
+export function getRatingScoreAnime(rating: number) {
   const decimal = (rating * 10).toString().split(".")[1];
   if (!decimal || decimal.length < 1) return (0.05 * (rating * 10)).toFixed(1);
   return (0.05 * (rating * 10)).toFixed(2);
+}
+
+export function getRatingScoreTMDB(rating: number) {
+  return rating.toFixed(1);
 }

--- a/src/services/thirdParty/movie/movieQueries.ts
+++ b/src/services/thirdParty/movie/movieQueries.ts
@@ -61,3 +61,27 @@ export function useMovieGenres() {
     }
   });
 }
+
+export function useMovieStreamLink(movieId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ["movieStream", movieId],
+    queryFn: async () => {
+      const headers = new Headers();
+      headers.append("x-api-key", import.meta.env.VITE_RABBIT_API_KEY);
+      const requestOptions: RequestInit = {
+        method: "GET",
+        headers,
+        redirect: "follow"
+      };
+      const streamLinkURL = await (
+        await fetch(
+          `${import.meta.env.VITE_RABBIT_URL}/${movieId}`,
+          requestOptions
+        )
+      ).text();
+
+      return streamLinkURL;
+    },
+    enabled: !!enabled
+  });
+}

--- a/src/services/thirdParty/movie/movieQueries.ts
+++ b/src/services/thirdParty/movie/movieQueries.ts
@@ -61,27 +61,3 @@ export function useMovieGenres() {
     }
   });
 }
-
-export function useMovieStreamLink(movieId: string, enabled: boolean) {
-  return useQuery({
-    queryKey: ["movieStream", movieId],
-    queryFn: async () => {
-      const headers = new Headers();
-      headers.append("x-api-key", import.meta.env.VITE_RABBIT_API_KEY);
-      const requestOptions: RequestInit = {
-        method: "GET",
-        headers,
-        redirect: "follow"
-      };
-      const streamLinkURL = await (
-        await fetch(
-          `${import.meta.env.VITE_RABBIT_URL}/${movieId}`,
-          requestOptions
-        )
-      ).text();
-
-      return streamLinkURL;
-    },
-    enabled: !!enabled
-  });
-}

--- a/src/services/thirdParty/movie/movieQueries.ts
+++ b/src/services/thirdParty/movie/movieQueries.ts
@@ -1,0 +1,63 @@
+import {
+  MovieInfo,
+  PaginatedMovieResponse
+} from "@/utils/types/thirdParty/movie/movieTmdb";
+import { MovieGenres } from "@/utils/types/thirdParty/movie/movieTmdb";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+const TMDB_API_KEY = import.meta.env.VITE_TMDB_API_KEY;
+const TMDB_API_URL = "https://api.themoviedb.org/3";
+export function useMoviesByCategory(category: string) {
+  return useQuery({
+    queryKey: ["categoryMovies", category],
+    queryFn: async () => {
+      let url: string;
+      if (category === "trending") {
+        url = `${TMDB_API_URL}/trending/movie/day?api_key=${TMDB_API_KEY}`;
+      } else if (category === "popular") {
+        url = `${TMDB_API_URL}/movie/popular?api_key=${TMDB_API_KEY}`;
+      } else {
+        url = `${TMDB_API_URL}/movie/top_rated?api_key=${TMDB_API_KEY}`;
+      }
+      const { data: categoryMovies } = await axios.get(url);
+      return categoryMovies as PaginatedMovieResponse;
+    }
+  });
+}
+
+export function useMovieInfo(movieId: string) {
+  return useQuery({
+    queryKey: ["movieInfo", movieId],
+    queryFn: async () => {
+      const { data: movieInfo } = await axios.get(
+        `${TMDB_API_URL}/movie/${movieId}?api_key=${TMDB_API_KEY}`
+      );
+      return movieInfo as MovieInfo;
+    }
+  });
+}
+
+export function useMovieRecommendations(movieId: string) {
+  return useQuery({
+    queryKey: ["movieRecommendations", movieId],
+    queryFn: async () => {
+      const { data: movieRecommendations } = await axios.get(
+        `${TMDB_API_URL}/movie/${movieId}/recommendations?api_key=${TMDB_API_KEY}`
+      );
+      return movieRecommendations as PaginatedMovieResponse;
+    }
+  });
+}
+
+export function useMovieGenres() {
+  return useQuery({
+    queryKey: ["movieGenres"],
+    queryFn: async () => {
+      const { data: movieGenres } = await axios.get(
+        `${TMDB_API_URL}/genre/movie/list?api_key=${TMDB_API_KEY}`
+      );
+      return movieGenres as MovieGenres;
+    }
+  });
+}

--- a/src/services/thirdParty/sharedFunctions.ts
+++ b/src/services/thirdParty/sharedFunctions.ts
@@ -1,0 +1,7 @@
+export function getTMDBImageURL(backdropPath: string) {
+  return `https://image.tmdb.org/t/p/original/${backdropPath}`;
+}
+
+export function getTMDBReleaseYear(releaseDate: string) {
+  return releaseDate.split("-")[0]
+}

--- a/src/services/thirdParty/sharedFunctions.ts
+++ b/src/services/thirdParty/sharedFunctions.ts
@@ -1,7 +1,44 @@
+import { RabbitScraperResponse } from "@/utils/types/thirdParty/shared";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
 export function getTMDBImageURL(backdropPath: string) {
   return `https://image.tmdb.org/t/p/original/${backdropPath}`;
 }
 
 export function getTMDBReleaseYear(releaseDate: string) {
-  return releaseDate.split("-")[0]
+  return releaseDate.split("-")[0];
+}
+
+type UseMediaScraperArgs = {
+  mediaId: string;
+  epNum?: number;
+  seasonNum?: number;
+  enabled: boolean;
+};
+
+export function useMediaScraper({
+  mediaId,
+  epNum,
+  seasonNum,
+  enabled
+}: UseMediaScraperArgs) {
+  return useQuery({
+    queryKey: ["mediaScraper", mediaId, epNum, seasonNum],
+    queryFn: async () => {
+      const rabbitApiBaseURL = "http://127.0.0.1:8787/api/rabbit/fetch";
+      let url: string;
+
+      if (epNum && seasonNum) {
+        url = `${rabbitApiBaseURL}?mediaId=${mediaId}?ss=${seasonNum}&ep=${epNum}`;
+      } else {
+        url = `${rabbitApiBaseURL}?mediaId=${mediaId}`;
+      }
+
+      const { data: rabbitResponse } = await axios.get(url);
+
+      return rabbitResponse as RabbitScraperResponse;
+    },
+    enabled: !!enabled
+  });
 }

--- a/src/utils/types/thirdParty/movie/movieTmdb.ts
+++ b/src/utils/types/thirdParty/movie/movieTmdb.ts
@@ -1,4 +1,4 @@
-import { PaginatedTMDBResponse, TMDBResource } from "../shared";
+import { PaginatedTMDBResponse, TMDBGenre, TMDBResource } from "../shared";
 
 export type PaginatedMovieResponse = PaginatedTMDBResponse & {
   results: MovieTMDB[];
@@ -8,4 +8,55 @@ export type MovieTMDB = TMDBResource & {
   title: string;
   original_title: string;
   release_date: string;
+};
+
+export type MovieInfo = {
+  adult: boolean;
+  backdrop_path: string;
+  belongs_to_collection: null;
+  budget: number;
+  genres: TMDBGenre[];
+  homepage: string;
+  id: number;
+  imdb_id: string;
+  origin_country: string[];
+  original_language: string;
+  original_title: string;
+  overview: string;
+  popularity: number;
+  poster_path: string;
+  production_companies: ProductionCompany[];
+  production_countries: ProductionCountry[];
+  release_date: string;
+  revenue: number;
+  runtime: number;
+  spoken_languages: SpokenLanguage[];
+  status: string;
+  tagline: string;
+  title: string;
+  video: boolean;
+  vote_average: number;
+  vote_count: number;
+};
+
+export type MovieGenres = {
+  genres: TMDBGenre[];
+};
+
+export type ProductionCompany = {
+  id: number;
+  logo_path: null | string;
+  name: string;
+  origin_country: string;
+};
+
+export type ProductionCountry = {
+  iso_3166_1: string;
+  name: string;
+};
+
+export type SpokenLanguage = {
+  english_name: string;
+  iso_639_1: string;
+  name: string;
 };

--- a/src/utils/types/thirdParty/shared.ts
+++ b/src/utils/types/thirdParty/shared.ts
@@ -32,3 +32,8 @@ export type PaginatedTMDBResponse = {
   total_pages: number;
   total_results: number;
 };
+
+export type TMDBGenre = {
+  id: number;
+  name: string;
+};

--- a/src/utils/types/thirdParty/shared.ts
+++ b/src/utils/types/thirdParty/shared.ts
@@ -37,3 +37,28 @@ export type TMDBGenre = {
   id: number;
   name: string;
 };
+
+export type RabbitScraperResponse = {
+  message?: string;
+  headers: Headers;
+  provider: string;
+  servers: string[];
+  url: URL[];
+  tracks: Subtitle[];
+  proxy: boolean;
+};
+
+export type Headers = {
+  Referer: string;
+};
+
+export type Subtitle = {
+  lang: string;
+  url: string;
+};
+
+export type URL = {
+  lang: string;
+  link: string;
+  type: string;
+};


### PR DESCRIPTION
In this PR I:

- added:
    - movies home page UI
    - movie info page UI
    - useQuery hooks to fetch movies data
    - more types for movies
    - movie episodes list and watch page initial UI
- finalized media scraping functionality by creating a useQuery hook called useMediaScraper in /services/thirdParty/sharedFunctions.ts
- used useMediaScraper for fetching episode data (url, subtitle tracks, etc.)
- added subtitle tracks in VideoPlayer.tsx
- created MovieEpisode.tsx similar to AnimeEpisodes.tsx, to handle rendering components based on the loading/error/success state of useMediaScraper
- added new type in /types/thirdParty/shared.ts:
    - RabbitScraperResponse (for useMediaQuery response type safety)